### PR TITLE
feat: allow callbacks as strings

### DIFF
--- a/src/app_model/types/_action.py
+++ b/src/app_model/types/_action.py
@@ -1,11 +1,12 @@
-from typing import Callable, Generic, List, Optional, TypeVar
+from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
 
-from pydantic import Field
+from pydantic import Field, validator
 from typing_extensions import ParamSpec
 
 from ._command_rule import CommandRule
 from ._keybinding_rule import KeyBindingRule
 from ._menu import MenuRule
+from ._utils import _validate_python_name
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -20,10 +21,13 @@ class Action(CommandRule, Generic[P, R]):
     `register_action`.
     """
 
-    # TODO: this could also be a string
-    callback: Callable[P, R] = Field(
+    callback: Union[Callable[P, R], str] = Field(
         ...,
-        description="A function to call when the associated command id is executed.",
+        description="A function to call when the associated command id is executed. "
+        "If a string is provided, it must be a fully qualified name to a callable "
+        "python object. This usually takes the form of "
+        "`{obj.__module__}:{obj.__qualname__}` "
+        "(e.g. `my_package.a_module:some_function`)",
     )
     menus: Optional[List[MenuRule]] = Field(
         None,
@@ -38,3 +42,8 @@ class Action(CommandRule, Generic[P, R]):
         description="Whether to add this command to the global Command Palette "
         "during registration.",
     )
+
+    @validator("callback")
+    def _validate_callback(callback: Any) -> Union[Callable, str]:
+        """Assert that `callback` is a callable or valid fully qualified name."""
+        return callback if callable(callback) else _validate_python_name(str(callback))

--- a/src/app_model/types/_action.py
+++ b/src/app_model/types/_action.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
+from typing import Callable, Generic, List, Optional, TypeVar, Union
 
 from pydantic import Field, validator
 from typing_extensions import ParamSpec
@@ -44,6 +44,10 @@ class Action(CommandRule, Generic[P, R]):
     )
 
     @validator("callback")
-    def _validate_callback(callback: Any) -> Union[Callable, str]:
+    def _validate_callback(callback: object) -> Union[Callable, str]:
         """Assert that `callback` is a callable or valid fully qualified name."""
-        return callback if callable(callback) else _validate_python_name(str(callback))
+        if callable(callback):
+            return callback
+        elif isinstance(callback, str):
+            return _validate_python_name(str(callback))
+        raise TypeError("callback must be a callable or a string")

--- a/src/app_model/types/_action.py
+++ b/src/app_model/types/_action.py
@@ -50,4 +50,4 @@ class Action(CommandRule, Generic[P, R]):
             return callback
         elif isinstance(callback, str):
             return _validate_python_name(str(callback))
-        raise TypeError("callback must be a callable or a string")
+        raise TypeError("callback must be a callable or a string")  # pragma: no cover

--- a/src/app_model/types/_utils.py
+++ b/src/app_model/types/_utils.py
@@ -1,0 +1,44 @@
+import re
+from importlib import import_module
+from typing import Any
+
+_identifier_plus_dash = "(?:[a-zA-Z_][a-zA-Z_0-9-]+)"
+_dotted_name = f"(?:(?:{_identifier_plus_dash}\\.)*{_identifier_plus_dash})"
+PYTHON_NAME_PATTERN = re.compile(f"^({_dotted_name}):({_dotted_name})$")
+
+
+def _validate_python_name(name: str) -> str:
+    """Assert that `name` is a valid python name: e.g. `module.submodule:funcname`."""
+    if name and not PYTHON_NAME_PATTERN.match(name):
+        msg = (
+            f"{name!r} is not a valid python_name.  A python_name must "
+            "be of the form '{obj.__module__}:{obj.__qualname__}' (e.g. "
+            "'my_package.a_module:some_function')."
+        )
+        if ".<locals>." in name:
+            *_, a, b = name.split(".<locals>.")
+            a = a.split(":")[-1]
+            msg += (
+                " Note: functions defined in local scopes are not yet supported. "
+                f"Please move function {b!r} to the global scope of module {a!r}"
+            )
+        raise ValueError(msg)
+    return name
+
+
+def import_python_name(python_name: str) -> Any:
+    """Import object from a fully qualified python name.
+
+    Examples
+    --------
+    >>> import_python_name("my_package.a_module:some_function")
+    <function some_function at 0x...>
+    >>> import_python_name('pydantic:BaseModel')
+    <class 'pydantic.main.BaseModel'>
+    """
+    _validate_python_name(python_name)  # shows the best error message
+    if match := PYTHON_NAME_PATTERN.match(python_name):
+        module_name, funcname = match.groups()
+        mod = import_module(module_name)
+        return getattr(mod, funcname)
+    raise ValueError(f"Could not parse python_name: {python_name!r}")

--- a/src/app_model/types/_utils.py
+++ b/src/app_model/types/_utils.py
@@ -11,7 +11,7 @@ def _validate_python_name(name: str) -> str:
     """Assert that `name` is a valid python name: e.g. `module.submodule:funcname`."""
     if name and not PYTHON_NAME_PATTERN.match(name):
         msg = (
-            f"{name!r} is not a valid python_name.  A python_name must "
+            f"{name!r} is not a valid python_name. A python_name must "
             "be of the form '{obj.__module__}:{obj.__qualname__}' (e.g. "
             "'my_package.a_module:some_function')."
         )

--- a/src/app_model/types/_utils.py
+++ b/src/app_model/types/_utils.py
@@ -15,7 +15,7 @@ def _validate_python_name(name: str) -> str:
             "be of the form '{obj.__module__}:{obj.__qualname__}' (e.g. "
             "'my_package.a_module:some_function')."
         )
-        if ".<locals>." in name:
+        if ".<locals>." in name:  # pragma: no cover
             *_, a, b = name.split(".<locals>.")
             a = a.split(":")[-1]
             msg += (
@@ -41,4 +41,6 @@ def import_python_name(python_name: str) -> Any:
         module_name, funcname = match.groups()
         mod = import_module(module_name)
         return getattr(mod, funcname)
-    raise ValueError(f"Could not parse python_name: {python_name!r}")
+    raise ValueError(  # pragma: no cover
+        f"Could not parse python_name: {python_name!r}"
+    )

--- a/tests/fixtures/fake_module.py
+++ b/tests/fixtures/fake_module.py
@@ -1,0 +1,11 @@
+from unittest.mock import Mock
+
+GLOBAL_MOCK = Mock(name="GLOBAL")
+
+
+def run_me() -> bool:
+    GLOBAL_MOCK()
+    return True
+
+
+attr = "not a callble"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -43,3 +44,40 @@ def test_sorting(full_app: FullApp):
 
     assert [i.command.title for i in g1] == ["Undo", "Redo"]
     assert [i.command.title for i in g2] == ["Copy", "Paste"]
+
+
+def test_action_import_by_string(full_app: FullApp):
+    """the REDO command is declared as a string in the conftest.py file
+
+    This tests that it can be lazily imported at callback runtime and executed
+    """
+    assert "fake_module" not in sys.modules
+    assert full_app.commands.execute_command(full_app.Commands.REDO).result()
+    assert "fake_module" in sys.modules
+    full_app.mocks.redo.assert_called_once()
+
+    # tests what happens when the module cannot be found
+    with pytest.raises(
+        ModuleNotFoundError, match="Command 'unimportable' was not importable"
+    ):
+        full_app.commands.execute_command(full_app.Commands.UNIMPORTABLE)
+    # the second time we try within a session, nothing should happen
+    full_app.commands.execute_command(full_app.Commands.UNIMPORTABLE)
+
+    # tests what happens when the object is not callable cannot be found
+    with pytest.raises(
+        TypeError,
+        match="Command 'not.callable' did not resolve to a callble object",
+    ):
+        full_app.commands.execute_command(full_app.Commands.NOT_CALLABLE)
+    # the second time we try within a session, nothing should happen
+    full_app.commands.execute_command(full_app.Commands.NOT_CALLABLE)
+
+
+def test_action_raises_exception(full_app: FullApp):
+    result = full_app.commands.execute_command(full_app.Commands.RAISES)
+    with pytest.raises(ValueError):
+        result.result()
+
+    # the function that raised the exception is `_raise_an_error` in conftest.py
+    assert str(result.exception()) == "This is an error"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,21 @@
-from app_model.types import Icon
+import pytest
+from pydantic import ValidationError
+
+from app_model.types import Action, Icon
 
 
 def test_icon_validate():
     assert Icon.validate('"fa5s.arrow_down"') == Icon(
         dark='"fa5s.arrow_down"', light='"fa5s.arrow_down"'
     )
+
+
+def test_action_validation():
+    with pytest.raises(ValidationError, match="'s!adf' is not a valid python_name"):
+        Action(id="test", title="test", callback="s!adf")
+
+    with pytest.raises(ValidationError):
+        Action(id="test", title="test", callback=list())
+
+    with pytest.raises(ValidationError, match="'x.<locals>:asdf' is not a valid"):
+        Action(id="test", title="test", callback="x.<locals>:asdf")


### PR DESCRIPTION
```python
        Action(
            id='some.command',
            title="Some Title",
            callback="my_module:some_function",  # resolve at calltime please
        ),
```